### PR TITLE
Feat/#81 서비스를 고려한 추가적인 기능 구현

### DIFF
--- a/src/main/java/org/com/moodbook/common/util/PageableUtil.java
+++ b/src/main/java/org/com/moodbook/common/util/PageableUtil.java
@@ -1,0 +1,29 @@
+package org.com.moodbook.common.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class PageableUtil {
+
+  /**
+   * !! 게시글 목록 조회 정렬 방법 세가지 !!
+   * views → viewCount DESC
+   * likes → likeCount DESC
+   * 기존방식 → createdAt DESC
+   */
+  public static Pageable of(int page, int size, String sortType) {
+    Sort sort;
+    switch (sortType.toLowerCase()) {
+      case "views":
+        sort = Sort.by("viewCount").descending();
+        break;
+      case "likes":
+        sort = Sort.by("likeCount").descending();
+        break;
+      default:
+        sort = Sort.by("createdAt").descending();
+    }
+    return PageRequest.of(page, size, sort);
+  }
+}

--- a/src/main/java/org/com/moodbook/post/controller/MeetingController.java
+++ b/src/main/java/org/com/moodbook/post/controller/MeetingController.java
@@ -3,6 +3,7 @@ package org.com.moodbook.post.controller;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.com.moodbook.common.util.PageableUtil;
 import org.com.moodbook.post.dto.CreateMeetingRequest;
 import org.com.moodbook.post.dto.MeetingDetailResponse;
 
@@ -43,7 +44,7 @@ public class MeetingController {
   }
 
   /**
-   * 모임 단일 조회
+   * 독서모임 단일 조회
    */
   @GetMapping("/{id}")
   public ResponseEntity<MeetingDetailResponse> getMeeting(
@@ -55,16 +56,20 @@ public class MeetingController {
   }
 
   /**
-   * 독서모임 목록 조회
+   * 독서모임 목록 조회 (정렬은 좋아요순 조회수순 최신순 가능)
    */
   @GetMapping
   public ResponseEntity<Page<MeetingSummaryResponse>> getMeetings(
       @AuthenticationPrincipal CustomMemberDetails md,
-      Pageable pageable
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "latest") String sortType
   ) {
-    Page<MeetingSummaryResponse> page = meetingService.getMeetings(md.getId(), pageable);
-    return ResponseEntity.ok(page);
+    Pageable pageable = PageableUtil.of(page, size, sortType);
+    Page<MeetingSummaryResponse> result = meetingService.getMeetings(md.getId(), pageable);
+    return ResponseEntity.ok(result);
   }
+
   /**
    * 모임 수정
    */

--- a/src/main/java/org/com/moodbook/post/controller/MeetingController.java
+++ b/src/main/java/org/com/moodbook/post/controller/MeetingController.java
@@ -46,18 +46,25 @@ public class MeetingController {
    * 모임 단일 조회
    */
   @GetMapping("/{id}")
-  public ResponseEntity<MeetingDetailResponse> getMeeting(@PathVariable Long id) {
-    return ResponseEntity.ok(meetingService.getMeeting(id));
+  public ResponseEntity<MeetingDetailResponse> getMeeting(
+      @AuthenticationPrincipal CustomMemberDetails md,
+      @PathVariable Long id
+  ) {
+    MeetingDetailResponse detail = meetingService.getMeeting(md.getId(), id);
+    return ResponseEntity.ok(detail);
   }
 
   /**
    * 독서모임 목록 조회
    */
   @GetMapping
-  public ResponseEntity<Page<MeetingSummaryResponse>> getMeetings(Pageable pageable) {
-    return ResponseEntity.ok(meetingService.getMeetings(pageable));
+  public ResponseEntity<Page<MeetingSummaryResponse>> getMeetings(
+      @AuthenticationPrincipal CustomMemberDetails md,
+      Pageable pageable
+  ) {
+    Page<MeetingSummaryResponse> page = meetingService.getMeetings(md.getId(), pageable);
+    return ResponseEntity.ok(page);
   }
-
   /**
    * 모임 수정
    */

--- a/src/main/java/org/com/moodbook/post/controller/MeetingController.java
+++ b/src/main/java/org/com/moodbook/post/controller/MeetingController.java
@@ -120,5 +120,17 @@ public class MeetingController {
     meetingService.respondToJoinRequest(md.getId(), meetingId, requestId, body);
     return ResponseEntity.noContent().build();
   }
+
+  /**
+   * 내가 만든 모임 및 참여중인 모임목록을 조회할수있는 엔드포인트(마이페이지)
+   */
+  @GetMapping("/api/meetings/my")
+  public ResponseEntity<Page<MeetingSummaryResponse>> getMyMeetings(
+      @AuthenticationPrincipal CustomMemberDetails md,
+      @RequestParam(defaultValue = "host") String role,
+      Pageable pageable
+  ) {
+    return ResponseEntity.ok(meetingService.getMyMeetings(md.getId(), role, pageable));
+  }
 }
 

--- a/src/main/java/org/com/moodbook/post/controller/ReportController.java
+++ b/src/main/java/org/com/moodbook/post/controller/ReportController.java
@@ -104,4 +104,15 @@ public class ReportController {
     Page<ReportSummaryResponse> page = reportService.getReportsByBook(bookId, pageable);
     return ResponseEntity.ok(page);
   }
+
+  /**
+   * 내가 쓴 독후감을 조회하기 위한 엔드포인트 (마이페이지)
+   */
+  @GetMapping("/api/reports/my")
+  public ResponseEntity<Page<ReportSummaryResponse>> getMyReports(
+      @AuthenticationPrincipal CustomMemberDetails md,
+      Pageable pageable
+  ) {
+    return ResponseEntity.ok(reportService.getMyReports(md.getId(), pageable));
+  }
 }

--- a/src/main/java/org/com/moodbook/post/controller/ReportController.java
+++ b/src/main/java/org/com/moodbook/post/controller/ReportController.java
@@ -2,6 +2,7 @@ package org.com.moodbook.post.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.com.moodbook.common.util.PageableUtil;
 import org.com.moodbook.post.dto.CreateReportRequest;
 import org.com.moodbook.post.dto.ReportDetailResponse;
 import org.com.moodbook.post.dto.ReportSummaryResponse;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -59,15 +61,18 @@ public class ReportController {
   }
 
   /**
-   * 독후감 목록 조회
+   * 독후감 목록 조회 (정렬 -> 최신순 좋아요순 조회수순)
    */
   @GetMapping
   public ResponseEntity<Page<ReportSummaryResponse>> getReports(
       @AuthenticationPrincipal CustomMemberDetails md,
-      Pageable pageable
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "latest") String sortType
   ) {
-    Page<ReportSummaryResponse> page = reportService.getReports(md.getId(), pageable);
-    return ResponseEntity.ok(page);
+    Pageable pageable = PageableUtil.of(page, size, sortType);
+    Page<ReportSummaryResponse> result = reportService.getReports(md.getId(), pageable);
+    return ResponseEntity.ok(result);
   }
 
   /**

--- a/src/main/java/org/com/moodbook/post/controller/ReportController.java
+++ b/src/main/java/org/com/moodbook/post/controller/ReportController.java
@@ -1,6 +1,7 @@
 package org.com.moodbook.post.controller;
 
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.com.moodbook.post.dto.CreateReportRequest;
 import org.com.moodbook.post.dto.ReportDetailResponse;
 import org.com.moodbook.post.dto.ReportSummaryResponse;
@@ -26,15 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/reports")
+@RequiredArgsConstructor
 @Validated
 public class ReportController {
 
   private final ReportService reportService;
-
-  @Autowired
-  public ReportController(ReportService reportService) {
-    this.reportService = reportService;
-  }
 
   /**
    * 독후감 작성
@@ -53,8 +50,11 @@ public class ReportController {
    * 단일 독후감 상세 조회
    */
   @GetMapping("/{id}")
-  public ResponseEntity<ReportDetailResponse> getReport(@PathVariable("id") Long id) {
-    ReportDetailResponse detail = reportService.getReport(id);
+  public ResponseEntity<ReportDetailResponse> getReport(
+      @AuthenticationPrincipal CustomMemberDetails md,
+      @PathVariable("id") Long id
+  ) {
+    ReportDetailResponse detail = reportService.getReport(md.getId(), id);
     return ResponseEntity.ok(detail);
   }
 
@@ -62,8 +62,11 @@ public class ReportController {
    * 독후감 목록 조회
    */
   @GetMapping
-  public ResponseEntity<Page<ReportSummaryResponse>> getReports(Pageable pageable) {
-    Page<ReportSummaryResponse> page = reportService.getReports(pageable);
+  public ResponseEntity<Page<ReportSummaryResponse>> getReports(
+      @AuthenticationPrincipal CustomMemberDetails md,
+      Pageable pageable
+  ) {
+    Page<ReportSummaryResponse> page = reportService.getReports(md.getId(), pageable);
     return ResponseEntity.ok(page);
   }
 

--- a/src/main/java/org/com/moodbook/post/controller/TagController.java
+++ b/src/main/java/org/com/moodbook/post/controller/TagController.java
@@ -1,0 +1,27 @@
+package org.com.moodbook.post.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.com.moodbook.post.dto.TagResponse;
+import org.com.moodbook.post.service.TagService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TagController {
+
+  private final TagService tagService;
+
+  /**
+   * 감정 태그 전체 조회 GET /api/tags
+   */
+  @GetMapping("/api/tags")
+  public ResponseEntity<List<TagResponse>> getAllTags() {
+    List<TagResponse> tags = tagService.getAllTags();
+    return ResponseEntity.ok(tags);
+  }
+}

--- a/src/main/java/org/com/moodbook/post/dto/MeetingDetailResponse.java
+++ b/src/main/java/org/com/moodbook/post/dto/MeetingDetailResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class MeetingDetailResponse {
+
   private Long id;
   private String title;
   private String content;
@@ -26,4 +27,5 @@ public class MeetingDetailResponse {
   private String hostName;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+  private boolean likedByMe;
 }

--- a/src/main/java/org/com/moodbook/post/dto/MeetingSummaryResponse.java
+++ b/src/main/java/org/com/moodbook/post/dto/MeetingSummaryResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class MeetingSummaryResponse {
+
   private Long id;
   private String title;
   private String hostName;
@@ -21,4 +22,5 @@ public class MeetingSummaryResponse {
   private int likeCount;
   private List<String> tags;
   private LocalDateTime createdAt;
+  private boolean likedByMe;
 }

--- a/src/main/java/org/com/moodbook/post/dto/ReportDetailResponse.java
+++ b/src/main/java/org/com/moodbook/post/dto/ReportDetailResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class ReportDetailResponse {
+
   private Long id;
   private String title;
   private String content;
@@ -21,4 +22,5 @@ public class ReportDetailResponse {
   private String authorName;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+  private boolean likedByMe;
 }

--- a/src/main/java/org/com/moodbook/post/dto/ReportSummaryResponse.java
+++ b/src/main/java/org/com/moodbook/post/dto/ReportSummaryResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class ReportSummaryResponse {
+
   private Long id;
   private String title;
   private String authorName;
@@ -17,4 +18,5 @@ public class ReportSummaryResponse {
   private int viewCount;
   private int likeCount;
   private List<String> tags;
+  private boolean likedByMe;
 }

--- a/src/main/java/org/com/moodbook/post/dto/TagResponse.java
+++ b/src/main/java/org/com/moodbook/post/dto/TagResponse.java
@@ -1,0 +1,12 @@
+package org.com.moodbook.post.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TagResponse {
+  private Long id;
+  private String name;
+}

--- a/src/main/java/org/com/moodbook/post/repository/MeetingMemberRepository.java
+++ b/src/main/java/org/com/moodbook/post/repository/MeetingMemberRepository.java
@@ -2,6 +2,8 @@ package org.com.moodbook.post.repository;
 
 import org.com.moodbook.common.constants.MeetingJoinStatus;
 import org.com.moodbook.post.entity.MeetingMember;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +15,8 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
   List<MeetingMember> findByMeetingIdAndStatus(Long meetingId, MeetingJoinStatus status);
 
   boolean existsByMeetingIdAndMemberId(Long meetingId, Long memberId);
+
+  // 내가 만든 모임 및 참여중인 모임 조회를 위해 필요 (마이페이지)
+  Page<MeetingMember> findByMemberIdAndStatus(Long memberId, MeetingJoinStatus status, Pageable pageable);
+
 }

--- a/src/main/java/org/com/moodbook/post/repository/MeetingRepository.java
+++ b/src/main/java/org/com/moodbook/post/repository/MeetingRepository.java
@@ -1,10 +1,13 @@
 package org.com.moodbook.post.repository;
 
 import org.com.moodbook.post.entity.Meeting;
+import org.com.moodbook.post.entity.Report;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
-
+  Page<Meeting> findByMember_Id(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/com/moodbook/post/repository/ReportRepository.java
+++ b/src/main/java/org/com/moodbook/post/repository/ReportRepository.java
@@ -10,4 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
   Page<Report> findByBook_Id(Long bookId, Pageable pageable);
+
+  // 마이페이지의 내 글 찾기 및 내 모임 찾기를 위해서 존재
+  Page<Report> findByMember_Id(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/com/moodbook/post/service/MeetingService.java
+++ b/src/main/java/org/com/moodbook/post/service/MeetingService.java
@@ -14,9 +14,9 @@ public interface MeetingService {
 
   Long createMeeting(Long memberId, CreateMeetingRequest request);
 
-  MeetingDetailResponse getMeeting(Long meetingId);
+  MeetingDetailResponse getMeeting(Long memberId, Long meetingId);
 
-  Page<MeetingSummaryResponse> getMeetings(Pageable pageable);
+  Page<MeetingSummaryResponse> getMeetings(Long memberId, Pageable pageable);
 
   // 모임 수정
   void updateMeeting(Long memberId, Long meetingId, UpdateMeetingRequest request);
@@ -35,7 +35,8 @@ public interface MeetingService {
 
   /**
    * 내가 만든(호스트) 또는 참가 중인 모임 목록 조회
-   * @param role "host" 또는 "participant"
+   *
+   * @param role host 또는 participant
    */
   Page<MeetingSummaryResponse> getMyMeetings(Long memberId, String role, Pageable pageable);
 }

--- a/src/main/java/org/com/moodbook/post/service/MeetingService.java
+++ b/src/main/java/org/com/moodbook/post/service/MeetingService.java
@@ -18,18 +18,24 @@ public interface MeetingService {
 
   Page<MeetingSummaryResponse> getMeetings(Pageable pageable);
 
-  /** 모임 수정 */
+  // 모임 수정
   void updateMeeting(Long memberId, Long meetingId, UpdateMeetingRequest request);
 
-  /** 모임 삭제 */
+  // 모임 삭제
   void deleteMeeting(Long memberId, Long meetingId);
 
-  /** 모임 참가 신청 */
+  // 모임 참가 신청
   void requestJoinMeeting(Long memberId, Long meetingId);
 
-  /** 모임장 승인/거절 */
+  // 모임장 승인/거절
   void respondToJoinRequest(Long hostId, Long meetingId, Long requestId, MeetingJoinResponseRequest req);
 
-  /** 모임장을 위한 메서드 - 대기 중인 신청 목록 조회 */
+  // 모임장을 위한 메서드 - 대기 중인 신청 목록 조회
   List<MeetingJoinDto> listJoinRequests(Long hostId, Long meetingId);
+
+  /**
+   * 내가 만든(호스트) 또는 참가 중인 모임 목록 조회
+   * @param role "host" 또는 "participant"
+   */
+  Page<MeetingSummaryResponse> getMyMeetings(Long memberId, String role, Pageable pageable);
 }

--- a/src/main/java/org/com/moodbook/post/service/ReportService.java
+++ b/src/main/java/org/com/moodbook/post/service/ReportService.java
@@ -26,4 +26,7 @@ public interface ReportService {
 
   // 특정 책에 달린 독후감 목록 조회 (도서 상세페이지에서 해당 도서의 독후감 목록조회를 위한 메서드)
   Page<ReportSummaryResponse> getReportsByBook(Long bookId, Pageable pageable);
+
+  // 내가 쓴 독후감 목록 조회
+  Page<ReportSummaryResponse> getMyReports(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/com/moodbook/post/service/ReportService.java
+++ b/src/main/java/org/com/moodbook/post/service/ReportService.java
@@ -1,5 +1,6 @@
 package org.com.moodbook.post.service;
 
+import org.com.moodbook.member.entity.Member;
 import org.com.moodbook.post.dto.CreateReportRequest;
 import org.com.moodbook.post.dto.ReportDetailResponse;
 import org.com.moodbook.post.dto.ReportSummaryResponse;
@@ -13,10 +14,10 @@ public interface ReportService {
   Long createReport(Long memberId, CreateReportRequest request);
 
   // 단일 독후감 조회
-  ReportDetailResponse getReport(Long reportId);
+  ReportDetailResponse getReport(Long memberId, Long reportId);
 
   // 독후감 목록 조회
-  Page<ReportSummaryResponse> getReports(Pageable pageable);
+  Page<ReportSummaryResponse> getReports(Long memberId, Pageable pageable);
 
   // 독후감 수정
   void updateReport(Long memberId, Long reportId, UpdateReportRequest request);

--- a/src/main/java/org/com/moodbook/post/service/TagService.java
+++ b/src/main/java/org/com/moodbook/post/service/TagService.java
@@ -1,0 +1,9 @@
+package org.com.moodbook.post.service;
+
+import java.util.List;
+import org.com.moodbook.post.dto.TagResponse;
+
+public interface TagService {
+  /** 모든 감정 태그 조회 */
+  List<TagResponse> getAllTags();
+}

--- a/src/main/java/org/com/moodbook/post/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/MeetingServiceImpl.java
@@ -86,13 +86,16 @@ public class MeetingServiceImpl implements MeetingService {
   }
 
   @Override
-  @Transactional(readOnly = true)
+  @Transactional
   public MeetingDetailResponse getMeeting(Long meetingId) {
     Meeting meeting = meetingRepository.findById(meetingId)
         .orElseThrow(() -> new BaseException(ErrorCode.MEETING_NOT_FOUND));
 
     int count = meetingMemberRepo.findByMeetingIdAndStatus(meetingId, MeetingJoinStatus.APPROVED)
         .size();
+
+    meeting.setViewCount(meeting.getViewCount() + 1);
+    meetingRepository.save(meeting);
 
     return MeetingDetailResponse.builder()
         .id(meeting.getId())
@@ -260,7 +263,8 @@ public class MeetingServiceImpl implements MeetingService {
   public Page<MeetingSummaryResponse> getMyMeetings(Long memberId, String role, Pageable pageable) {
     if ("participant".equalsIgnoreCase(role)) {
       // 내가 참가된 모임만
-      Page<MeetingMember> joins = meetingMemberRepo.findByMemberIdAndStatus(memberId, MeetingJoinStatus.APPROVED, pageable);
+      Page<MeetingMember> joins = meetingMemberRepo.findByMemberIdAndStatus(memberId, MeetingJoinStatus.APPROVED,
+          pageable);
       return joins.map(j -> {
         Meeting m = j.getMeeting();
         int count = meetingMemberRepo.findByMeetingIdAndStatus(m.getId(), MeetingJoinStatus.APPROVED).size();

--- a/src/main/java/org/com/moodbook/post/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/MeetingServiceImpl.java
@@ -37,7 +37,7 @@ public class MeetingServiceImpl implements MeetingService {
   private final MeetingRepository meetingRepository;
   private final MemberRepository memberRepository;
   private final MoodTagRepository tagRepository;
-  private final MeetingMemberRepository memberRepo;
+  private final MeetingMemberRepository meetingMemberRepo;
 
   @Override
   public Long createMeeting(Long memberId, CreateMeetingRequest req) {
@@ -80,7 +80,7 @@ public class MeetingServiceImpl implements MeetingService {
         .status(MeetingJoinStatus.APPROVED)
         .joinedAt(meeting.getCreatedAt())
         .build();
-    memberRepo.save(self);
+    meetingMemberRepo.save(self);
 
     return meeting.getId();
   }
@@ -91,7 +91,7 @@ public class MeetingServiceImpl implements MeetingService {
     Meeting meeting = meetingRepository.findById(meetingId)
         .orElseThrow(() -> new BaseException(ErrorCode.MEETING_NOT_FOUND));
 
-    int count = memberRepo.findByMeetingIdAndStatus(meetingId, MeetingJoinStatus.APPROVED)
+    int count = meetingMemberRepo.findByMeetingIdAndStatus(meetingId, MeetingJoinStatus.APPROVED)
         .size();
 
     return MeetingDetailResponse.builder()
@@ -126,7 +126,7 @@ public class MeetingServiceImpl implements MeetingService {
             .meetingType(m.getMeetingType().name())
             .startAt(m.getStartAt())
             .currentParticipants(
-                memberRepo.findByMeetingIdAndStatus(m.getId(), MeetingJoinStatus.APPROVED)
+                meetingMemberRepo.findByMeetingIdAndStatus(m.getId(), MeetingJoinStatus.APPROVED)
                     .size()
             )
             .capacity(m.getCapacity())
@@ -193,7 +193,7 @@ public class MeetingServiceImpl implements MeetingService {
     Meeting meeting = meetingRepository.findById(meetingId)
         .orElseThrow(() -> new BaseException(ErrorCode.MEETING_NOT_FOUND));
 
-    if (memberRepo.existsByMeetingIdAndMemberId(meetingId, memberId)) {
+    if (meetingMemberRepo.existsByMeetingIdAndMemberId(meetingId, memberId)) {
       throw new BaseException(ErrorCode.ALREADY_EXIST_JOIN);
     }
 
@@ -205,7 +205,7 @@ public class MeetingServiceImpl implements MeetingService {
         .member(member)
         .status(MeetingJoinStatus.PENDING)
         .build();
-    memberRepo.save(req);
+    meetingMemberRepo.save(req);
   }
 
   @Override
@@ -216,7 +216,7 @@ public class MeetingServiceImpl implements MeetingService {
       throw new BaseException(ErrorCode.ACCESS_DENIED);
     }
 
-    MeetingMember req = memberRepo.findById(requestId)
+    MeetingMember req = meetingMemberRepo.findById(requestId)
         .orElseThrow(() -> new BaseException(ErrorCode.JOIN_REQUEST_NOT_FOUND));
     if (!req.getMeeting().getId().equals(meetingId)) {
       throw new BaseException(ErrorCode.INVALID_REQUEST);
@@ -231,7 +231,7 @@ public class MeetingServiceImpl implements MeetingService {
     } else {
       throw new BaseException(ErrorCode.INVALID_ACTION);
     }
-    memberRepo.save(req);
+    meetingMemberRepo.save(req);
   }
 
   @Override
@@ -243,7 +243,7 @@ public class MeetingServiceImpl implements MeetingService {
       throw new BaseException(ErrorCode.ACCESS_DENIED);
     }
 
-    return memberRepo.findByMeetingIdAndStatus(meetingId, MeetingJoinStatus.PENDING)
+    return meetingMemberRepo.findByMeetingIdAndStatus(meetingId, MeetingJoinStatus.PENDING)
         .stream()
         .map(r -> new MeetingJoinDto(
             r.getId(),
@@ -253,6 +253,51 @@ public class MeetingServiceImpl implements MeetingService {
             r.getCreatedAt().toString()
         ))
         .collect(Collectors.toList());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<MeetingSummaryResponse> getMyMeetings(Long memberId, String role, Pageable pageable) {
+    if ("participant".equalsIgnoreCase(role)) {
+      // 내가 참가된 모임만
+      Page<MeetingMember> joins = meetingMemberRepo.findByMemberIdAndStatus(memberId, MeetingJoinStatus.APPROVED, pageable);
+      return joins.map(j -> {
+        Meeting m = j.getMeeting();
+        int count = meetingMemberRepo.findByMeetingIdAndStatus(m.getId(), MeetingJoinStatus.APPROVED).size();
+        return MeetingSummaryResponse.builder()
+            .id(m.getId())
+            .title(m.getTitle())
+            .hostName(m.getMember().getName())
+            .meetingType(m.getMeetingType().name())
+            .startAt(m.getStartAt())
+            .currentParticipants(count)
+            .capacity(m.getCapacity())
+            .viewCount(m.getViewCount())
+            .likeCount(m.getLikeCount())
+            .tags(m.getMoodTags().stream().map(MoodTag::getName).toList())
+            .createdAt(m.getCreatedAt())
+            .build();
+      });
+    } else {
+      // role=host 부분
+      return meetingRepository.findByMember_Id(memberId, pageable)
+          .map(m -> {
+            int count = meetingMemberRepo.findByMeetingIdAndStatus(m.getId(), MeetingJoinStatus.APPROVED).size();
+            return MeetingSummaryResponse.builder()
+                .id(m.getId())
+                .title(m.getTitle())
+                .hostName(m.getMember().getName())
+                .meetingType(m.getMeetingType().name())
+                .startAt(m.getStartAt())
+                .currentParticipants(count)
+                .capacity(m.getCapacity())
+                .viewCount(m.getViewCount())
+                .likeCount(m.getLikeCount())
+                .tags(m.getMoodTags().stream().map(MoodTag::getName).toList())
+                .createdAt(m.getCreatedAt())
+                .build();
+          });
+    }
   }
 
 }

--- a/src/main/java/org/com/moodbook/post/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/MeetingServiceImpl.java
@@ -20,6 +20,7 @@ import org.com.moodbook.post.entity.MoodTag;
 import org.com.moodbook.post.repository.MeetingMemberRepository;
 import org.com.moodbook.post.repository.MeetingRepository;
 import org.com.moodbook.post.repository.MoodTagRepository;
+import org.com.moodbook.post.service.LikeService;
 import org.com.moodbook.post.service.MeetingService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +39,7 @@ public class MeetingServiceImpl implements MeetingService {
   private final MemberRepository memberRepository;
   private final MoodTagRepository tagRepository;
   private final MeetingMemberRepository meetingMemberRepo;
+  private final LikeService likeService;
 
   @Override
   public Long createMeeting(Long memberId, CreateMeetingRequest req) {
@@ -87,7 +89,7 @@ public class MeetingServiceImpl implements MeetingService {
 
   @Override
   @Transactional
-  public MeetingDetailResponse getMeeting(Long meetingId) {
+  public MeetingDetailResponse getMeeting(Long memberId, Long meetingId) {
     Meeting meeting = meetingRepository.findById(meetingId)
         .orElseThrow(() -> new BaseException(ErrorCode.MEETING_NOT_FOUND));
 
@@ -96,6 +98,8 @@ public class MeetingServiceImpl implements MeetingService {
 
     meeting.setViewCount(meeting.getViewCount() + 1);
     meetingRepository.save(meeting);
+
+    boolean liked = likeService.isLikedBy(memberId, meetingId);
 
     return MeetingDetailResponse.builder()
         .id(meeting.getId())
@@ -115,12 +119,13 @@ public class MeetingServiceImpl implements MeetingService {
         .hostName(meeting.getMember().getName())
         .createdAt(meeting.getCreatedAt())
         .updatedAt(meeting.getUpdatedAt())
+        .likedByMe(liked)
         .build();
   }
 
   @Override
   @Transactional(readOnly = true)
-  public Page<MeetingSummaryResponse> getMeetings(Pageable pageable) {
+  public Page<MeetingSummaryResponse> getMeetings(Long memberId, Pageable pageable) {
     return meetingRepository.findAll(pageable)
         .map(m -> MeetingSummaryResponse.builder()
             .id(m.getId())
@@ -139,6 +144,7 @@ public class MeetingServiceImpl implements MeetingService {
                 .map(MoodTag::getName)
                 .collect(Collectors.toList()))
             .createdAt(m.getCreatedAt())
+            .likedByMe(likeService.isLikedBy(memberId, m.getId()))
             .build()
         );
   }

--- a/src/main/java/org/com/moodbook/post/service/impl/ReportServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/ReportServiceImpl.java
@@ -15,6 +15,7 @@ import org.com.moodbook.post.entity.Report;
 import org.com.moodbook.post.entity.MoodTag;
 import org.com.moodbook.post.repository.MoodTagRepository;
 import org.com.moodbook.post.repository.ReportRepository;
+import org.com.moodbook.post.service.LikeService;
 import org.com.moodbook.post.service.ReportService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,6 +34,7 @@ public class ReportServiceImpl implements ReportService {
   private final BookRepository bookRepository;
   private final MemberRepository memberRepository;
   private final MoodTagRepository tagRepository;
+  private final LikeService likeService;
 
   @Override
   public Long createReport(Long memberId, CreateReportRequest req) {
@@ -65,12 +67,14 @@ public class ReportServiceImpl implements ReportService {
 
   @Override
   @Transactional(readOnly = true)
-  public ReportDetailResponse getReport(Long reportId) {
+  public ReportDetailResponse getReport(Long memberId, Long reportId) {
     Report report = reportRepository.findById(reportId)
         .orElseThrow(() -> new BaseException(ErrorCode.REPORT_NOT_FOUND));
 
-    report.setViewCount(report.getViewCount() +1);
+    report.setViewCount(report.getViewCount() + 1);
     reportRepository.save(report);
+
+    boolean liked = likeService.isLikedBy(memberId, reportId);
 
     return ReportDetailResponse.builder()
         .id(report.getId())
@@ -85,12 +89,13 @@ public class ReportServiceImpl implements ReportService {
         .authorName(report.getMember().getName())
         .createdAt(report.getCreatedAt())
         .updatedAt(report.getUpdatedAt())
+        .likedByMe(liked)
         .build();
   }
 
   @Override
   @Transactional(readOnly = true)
-  public Page<ReportSummaryResponse> getReports(Pageable pageable) {
+  public Page<ReportSummaryResponse> getReports(Long memberId, Pageable pageable) {
     return reportRepository.findAll(pageable)
         .map(r -> ReportSummaryResponse.builder()
             .id(r.getId())
@@ -102,6 +107,7 @@ public class ReportServiceImpl implements ReportService {
             .tags(r.getMoodTags().stream()
                 .map(MoodTag::getName)
                 .collect(Collectors.toList()))
+            .likedByMe(likeService.isLikedBy(memberId, r.getId()))
             .build()
         );
   }

--- a/src/main/java/org/com/moodbook/post/service/impl/ReportServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/ReportServiceImpl.java
@@ -69,6 +69,9 @@ public class ReportServiceImpl implements ReportService {
     Report report = reportRepository.findById(reportId)
         .orElseThrow(() -> new BaseException(ErrorCode.REPORT_NOT_FOUND));
 
+    report.setViewCount(report.getViewCount() +1);
+    reportRepository.save(report);
+
     return ReportDetailResponse.builder()
         .id(report.getId())
         .title(report.getTitle())

--- a/src/main/java/org/com/moodbook/post/service/impl/ReportServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/ReportServiceImpl.java
@@ -155,4 +155,21 @@ public class ReportServiceImpl implements ReportService {
             .build()
         );
   }
+
+  // 내가 쓴 독후감들 전체 조회 (마이페이지에서 가능)
+  @Override
+  @Transactional(readOnly = true)
+  public Page<ReportSummaryResponse> getMyReports(Long memberId, Pageable pageable) {
+    return reportRepository.findByMember_Id(memberId, pageable)
+        .map(r -> ReportSummaryResponse.builder()
+            .id(r.getId())
+            .title(r.getTitle())
+            .authorName(r.getMember().getName())
+            .createdAt(r.getCreatedAt())
+            .viewCount(r.getViewCount())
+            .likeCount(r.getLikeCount())
+            .tags(r.getMoodTags().stream().map(MoodTag::getName).toList())
+            .build()
+        );
+  }
 }

--- a/src/main/java/org/com/moodbook/post/service/impl/TagServiceImpl.java
+++ b/src/main/java/org/com/moodbook/post/service/impl/TagServiceImpl.java
@@ -1,0 +1,29 @@
+package org.com.moodbook.post.service.impl;
+
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.com.moodbook.post.dto.TagResponse;
+import org.com.moodbook.post.repository.MoodTagRepository;
+import org.com.moodbook.post.service.TagService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagServiceImpl implements TagService {
+
+  private final MoodTagRepository tagRepository;
+
+  /**
+   * 태그 선택에 보여줘야 하므로 모든 저장된 태그 조회 하는 로직
+   */
+  @Override
+  public List<TagResponse> getAllTags() {
+    return tagRepository.findAll().stream()
+        .map(tag -> new TagResponse(tag.getId(), tag.getName()))
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
# 요약

프론트엔드 코드와 사용자 UI를 고려하여 필요할것같은 추가 기능의 구현 및 기존 기능의 수정을 진행

1. 글 작성시에 감정태그를 선택할 수 있도록 저장된 감정태그 목록을 불러오는 API를 구현
2. 마이페이지에서 사용자가 자신이 쓴 독후감이나 만든,참가 중인 모임만 따로 보기 위한 내 글/내 모임 조회 기능 구현
3. 독후감 및 독서모임 글 상세 조회 시 조회수 증가 로직 추가
4. 독후감 및 독서모임 글에 유저가 좋아요를 눌렀는지 여부에 대한 로직 추가
5. 글 목록조회의 정렬기능을 최신순 한정에서 좋아요순, 조회수순, 최신순으로 조회 가능하도록 확장

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#81 

close #81 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현
